### PR TITLE
fix format arguments

### DIFF
--- a/pact/todos.pact
+++ b/pact/todos.pact
@@ -119,7 +119,7 @@
 
   (defun id-key (id:integer)
     "Format ID integer value as todo row key."
-    (format "{}" id)
+    (format "{}" [id])
   )
 
 


### PR DESCRIPTION
Fix arguments for `format` form, changed on [Pact 2.3.0](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md#230).