### PR TITLE
fixed database/purity error when editing todo. Added toggle-todo check. 

### DIFF
--- a/pact/todos.pact
+++ b/pact/todos.pact
@@ -112,10 +112,10 @@
   (defun enforce-not-deleted (id:integer)
     "Enforce row exists at ID and deleted flag is not set. \
     \ Also returns formatted row key."
-    (let ((key (id-key id)))
-      (enforce (not-deleted (read todo-table key))
+    (let ((row (read todo-table (id-key id))))
+      (enforce (not-deleted row)
         "todo must not be deleted")
-      key))
+      (id-key id)))
 
 
   (defun id-key (id:integer)

--- a/pact/todos.repl
+++ b/pact/todos.repl
@@ -11,3 +11,4 @@
 (new-todo "get bread")
 (read-todo 0)
 (toggle-todo-status 0)
+(read-todo 0)


### PR DESCRIPTION
**GOAL:** Get Pact-TodoMVC working with the latest version of Pact (which I assumed to be the version available on homebrew, v2.3.8).

**PROCESS:** 
1. Downloaded latest version of Pact using Homebrew and followed the rest of the instructions on the Pact-TodoMVC Readme. 

2. Opened the web app and started adding, deleting, editing, completing todos. After every action, I looked at the server logs for errors/warnings. 

3. The web app worked as expected and no ERROR messages were logged, _except_ when I tried to edit a todo. The web app didn't register the edits and the server outputted the following ERROR message: 
`2018/05/08-14:09:58 [PactService] ERROR tx failure for requestKey: "c21cfd5579623b02af8c584c779851f26e89f094786dc492e13ae324b6db83f46d44c50202567b339988a9eb8a873aa749af330758d44b182f459ad435d0ac63": (read todo-table key): Failure: Database exception: : Failure: Illegal database access in pure context\`

4. To verify that this wasn't an old error, I ran the web app using [Pact version 2.1.0](http://kadena.io/pact/downloads.html). When using this version of Pact, editing todos worked as expected and no error messages were logged by the server. Therefore, the error message must be a result of a recent change to Pact. 

5. The error was occurring in the `enforce-not-deleted` function, specifically in `enforce (not-deleted (read todo-table key)`. The latest version of Pact requires that [`enforce` be used with a pure function](http://pact-language.readthedocs.io/en/latest/pact-reference.html#enforce). But this code had been trying to access the database while calling `enforce`'s test function. 

**SOLUTION:**
Bound the result of accessing the database (`read todo-table key`) to a variable and then passed this variable into `enforce`'s test function. Thus making the function pure. After implementing this approach, editing todos worked as expected and no errors were logged. 

**OTHER:**
1. I added another call to `read-todo` in `todo.repl` to visually verify that my changes to `enforce-not-deleted` didn't break the `toggle-todo-status` function. The `toggle` function is the only other function that uses `enforce-not-deleted`. Moreover, `toggle` is only called in the .repl file and thus couldn't be visually tested in the web app. 
2. I accidentally did a force push with these changes to master, but I reverted them so they can be reviewed in this PR. 


